### PR TITLE
Fix analyse endpoint, add tests

### DIFF
--- a/mindsdb_server/namespaces/predictor.py
+++ b/mindsdb_server/namespaces/predictor.py
@@ -233,7 +233,7 @@ class AnalyseDataset(Resource):
     def get(self, name):
         from_data = get_datasource_path(request.args.get('data_source_name'))
         if from_data is None:
-            from_data = data.get('from_data')
+            from_data = request.args.get('from_data')
         if from_data is None:
             print('No valid datasource given')
             return 'No valid datasource given', 400

--- a/tests/ci_tests/test_endpoints.py
+++ b/tests/ci_tests/test_endpoints.py
@@ -34,20 +34,19 @@ class PredictorTest(unittest.TestCase):
 
     def test_analyse_invalid_datasource(self):
         """
-        Call unexisting predictor
-        then check the response is NOT FOUND
+        Don't provide datasource
+        then check the response is No valid datasource given
         """
         response = self.app.get('/predictors/dummy_predictor/analyse_dataset')
         assert response.status_code == 400
 
-    def test_analyse_invalid_datasource(self):
+    def test_analyse_valid_datasource(self):
         """
-        Call unexisting predictor
-        then check the response is NOT FOUND
+        Add valid datasource as parameter
+        then check the response is 200
         """
         from_data = 'https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/benchmarks/heart_disease/processed_data/train.csv'
         response = self.app.get('/predictors/dummy_predictor/analyse_dataset?from_data='+ from_data)
-        print(response)
         assert response.status_code == 200
 
 class DatasourceTest(unittest.TestCase):

--- a/tests/ci_tests/test_endpoints.py
+++ b/tests/ci_tests/test_endpoints.py
@@ -32,6 +32,23 @@ class PredictorTest(unittest.TestCase):
         response = self.app.get('/predictors/dummy_predictor')
         assert response.status_code == 404
 
+    def test_analyse_invalid_datasource(self):
+        """
+        Call unexisting predictor
+        then check the response is NOT FOUND
+        """
+        response = self.app.get('/predictors/dummy_predictor/analyse_dataset')
+        assert response.status_code == 400
+
+    def test_analyse_invalid_datasource(self):
+        """
+        Call unexisting predictor
+        then check the response is NOT FOUND
+        """
+        from_data = 'https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/benchmarks/heart_disease/processed_data/train.csv'
+        response = self.app.get('/predictors/dummy_predictor/analyse_dataset?from_data='+ from_data)
+        print(response)
+        assert response.status_code == 200
 
 class DatasourceTest(unittest.TestCase):
 


### PR DESCRIPTION
This PR fixes the anaylse_dataset endpoint when from_data is provided in query params since this is a Get request. Also, there are 2 tests added to test the valid analyze params and invalid ones.