### PR TITLE
Use basic form for parameter expansion.

### DIFF
--- a/install_scripts/install_venv_linux_macos.sh
+++ b/install_scripts/install_venv_linux_macos.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-"$PYPATH" -m pip install --user --upgrade pip
-"$PYPATH" -m pip install --user virtualenv
-mkdir -p "$SERVER_PATH" || mkdir "$SERVER_PATH"
+"${PYPATH}" -m pip install --user --upgrade pip
+"${PYPATH}" -m pip install --user virtualenv
+mkdir -p "${SERVER_PATH}" || mkdir "${SERVER_PATH}"
 
-cd "$SERVER_PATH"
+cd "${SERVER_PATH}"
 
-"$PYPATH" -m virtualenv env --python="$PYPATH"
+"${PYPATH}" -m virtualenv env --python="${PYPATH}"
 
 source env/bin/activate
 env/bin/pip3 install --upgrade pip || env/bin/pip install --upgrade pip

--- a/install_scripts/upgrade_venv_linux_macos.sh
+++ b/install_scripts/upgrade_venv_linux_macos.sh
@@ -2,7 +2,7 @@
 
 
 
-cd "$SERVER_PATH"
+cd "${SERVER_PATH}"
 
 source env/bin/activate
 env/bin/pip3 install --upgrade pip || env/bin/pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     install_requires=requirements,
     classifiers=(
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ),
     python_requires=">=3.6"


### PR DESCRIPTION
This is a fix for issue #57.

Bash parameter expansions must be in basic form for spaces to work.

<https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html>

*disclaimer*:
I only tested this fix on Linux, but the results should be the same.