### PR TITLE
method _learn moved to separate file

### DIFF
--- a/mindsdb_server/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb_server/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -1,5 +1,4 @@
 import pandas
-import mindsdb
 
 from mindsdb_server.api.mysql.mysql_proxy.datahub.datanodes.datanode import DataNode
 from mindsdb_server.interfaces.native.mindsdb import MindsdbNative
@@ -22,8 +21,8 @@ class MindsDBDataNode(DataNode):
 
     def getTableColumns(self, table):
         if table == 'predictors':
-            return ['name', 'predict_cols', 'select_data_query', 'training_options']
-        model = mindsdb.Predictor(name=table).get_model_data()
+            return ['name', 'status', 'accuracy', 'predict_cols', 'select_data_query', 'training_options']
+        model = self.mindsdb_native.get_model_data(name=table)
         columns = []
         columns += [x['column_name'] for x in model['data_analysis']['input_columns_metadata']]
         columns += [x['column_name'] for x in model['data_analysis']['target_columns_metadata']]
@@ -33,9 +32,11 @@ class MindsDBDataNode(DataNode):
         models = self.mindsdb_native.get_models()
         return [{
             'name': x['name'],
+            'status': x['status'],
+            'accuracy': x['accuracy'],
             'predict_cols': ', '.join(x['predict']),
             'select_data_query': x['data_source'],
-            'training_options': ''
+            'training_options': ''  # TODEL ?
         } for x in models]
 
     def delete_predictor(self, name):
@@ -52,16 +53,16 @@ class MindsDBDataNode(DataNode):
                 # TODO value should be just string or number
                 raise Exception()
             new_where[key] = value['$eq']
-        p = mindsdb.Predictor(name=table)
 
         if where_data is not None:
             where_data = pandas.DataFrame(where_data)
-        res = p.predict(when=new_where, when_data=where_data, use_gpu=False)
 
-        predicted_columns = p.get_model_data()['predict']
+        res = self.mindsdb_native.predict(name=table, when=new_where, when_data=where_data)
+
+        predicted_columns = self.mindsdb_native.get_model_data(name=table)['predict']
         length = len(res.data[predicted_columns[0]])
+
         data = []
-        # keys = [x for x in list(res.data.keys()) if x in columns and x in predicted_columns]
         keys = [x for x in list(res.data.keys()) if x in columns]
         for i in range(length):
             row = {}

--- a/mindsdb_server/default_config.json
+++ b/mindsdb_server/default_config.json
@@ -1,5 +1,6 @@
 {
     "debug": true,
+    "use_gpu": false,
     "config_version": 1,
     "python_interpreter": "/usr/bin/python3",
     "api": {

--- a/mindsdb_server/interfaces/clickhouse/clickhouse.py
+++ b/mindsdb_server/interfaces/clickhouse/clickhouse.py
@@ -15,17 +15,17 @@ class Clickhouse():
 
     def _to_clickhouse_table(self, stats):
         subtype_map = {
-            DATA_SUBTYPES.INT: 'Int64',
-            DATA_SUBTYPES.FLOAT: 'Float64',
-            DATA_SUBTYPES.BINARY: 'UInt8',
-            DATA_SUBTYPES.DATE: 'Date',
-            DATA_SUBTYPES.TIMESTAMP: 'Datetime',
-            DATA_SUBTYPES.SINGLE: 'String',
-            DATA_SUBTYPES.MULTIPLE: 'String',
-            DATA_SUBTYPES.IMAGE: 'String',
-            DATA_SUBTYPES.VIDEO: 'String',
-            DATA_SUBTYPES.AUDIO: 'String',
-            DATA_SUBTYPES.TEXT: 'String',
+            DATA_SUBTYPES.INT: 'Nullable(Int64)',
+            DATA_SUBTYPES.FLOAT: 'Nullable(Float64)',
+            DATA_SUBTYPES.BINARY: 'Nullable(UInt8)',
+            DATA_SUBTYPES.DATE: 'Nullable(Date)',
+            DATA_SUBTYPES.TIMESTAMP: 'Nullable(Datetime)',
+            DATA_SUBTYPES.SINGLE: 'Nullable(String)',
+            DATA_SUBTYPES.MULTIPLE: 'Nullable(String)',
+            DATA_SUBTYPES.IMAGE: 'Nullable(String)',
+            DATA_SUBTYPES.VIDEO: 'Nullable(String)',
+            DATA_SUBTYPES.AUDIO: 'Nullable(String)',
+            DATA_SUBTYPES.TEXT: 'Nullable(String)',
             DATA_SUBTYPES.ARRAY: 'Array(Float64)'
         }
 
@@ -63,13 +63,15 @@ class Clickhouse():
     def setup_clickhouse(self):
         self._query('CREATE DATABASE IF NOT EXISTS mindsdb')
 
-        msqyl_conn =  self.config['api']['mysql']['host'] + ':' + str(self.config['api']['mysql']['port'])
-        msqyl_user =  self.config['api']['mysql']['user']
-        msqyl_pass =  self.config['api']['mysql']['password']
+        msqyl_conn = self.config['api']['mysql']['host'] + ':' + str(self.config['api']['mysql']['port'])
+        msqyl_user = self.config['api']['mysql']['user']
+        msqyl_pass = self.config['api']['mysql']['password']
 
         q = f"""
                 CREATE TABLE IF NOT EXISTS mindsdb.predictors
                 (name String,
+                status String,
+                accuracy String,
                 predict_cols String,
                 select_data_query String,
                 training_options String
@@ -78,14 +80,12 @@ class Clickhouse():
         print(f'Executing table creation query to create predictors list:\n{q}\n')
         self._query(q)
 
-
-
     def register_predictor(self, name, stats):
         columns_sql = ','.join(self._to_clickhouse_table(stats))
 
-        msqyl_conn =  self.config['api']['mysql']['host'] + ':' + str(self.config['api']['mysql']['port'])
-        msqyl_user =  self.config['api']['mysql']['user']
-        msqyl_pass =  self.config['api']['mysql']['password']
+        msqyl_conn = self.config['api']['mysql']['host'] + ':' + str(self.config['api']['mysql']['port'])
+        msqyl_user = self.config['api']['mysql']['user']
+        msqyl_pass = self.config['api']['mysql']['password']
 
         q = f"""
                 CREATE TABLE mindsdb.{name}

--- a/mindsdb_server/interfaces/native/learn_process.py
+++ b/mindsdb_server/interfaces/native/learn_process.py
@@ -33,8 +33,7 @@ class LearnProcess(ctx.Process):
         mdb.learn(
             from_data=data_source,
             to_predict=to_predict,
-            #Needs to be fixed
-            use_gpu=True,
+            use_gpu=self.config.get('use_gpu', False),
             **kwargs
         )
 

--- a/mindsdb_server/interfaces/native/learn_process.py
+++ b/mindsdb_server/interfaces/native/learn_process.py
@@ -25,8 +25,6 @@ class LearnProcess(ctx.Process):
         config = Config(config)
 
         mdb = mindsdb.Predictor(name=name)
-        if sys.platform not in ['win32','cygwin','windows']:
-            lightwood.config.config.CONFIG.HELPER_MIXERS = True
 
         data_source = getattr(mindsdb, from_data['class'])(*from_data['args'], **from_data['kwargs'])
 

--- a/mindsdb_server/interfaces/native/learn_process.py
+++ b/mindsdb_server/interfaces/native/learn_process.py
@@ -1,0 +1,49 @@
+import torch.multiprocessing as mp
+
+
+ctx = mp.get_context('spawn')
+class LearnProcess(ctx.Process):
+    daemon = True
+
+    def __init__(self, *args):
+        super(LearnProcess, self).__init__(args=args)
+
+    def run(self):
+        '''
+        running at subprocess due to
+        ValueError: signal only works in main thread
+
+        this is work for celery worker here?
+        '''
+        import sys
+        import mindsdb
+        import lightwood
+
+        from mindsdb_server.utilities.config import Config
+
+        name, from_data, to_predict, kwargs, config = self._args
+        config = Config(config)
+
+        mdb = mindsdb.Predictor(name=name)
+        if sys.platform not in ['win32','cygwin','windows']:
+            lightwood.config.config.CONFIG.HELPER_MIXERS = True
+
+        data_source = getattr(mindsdb, from_data['class'])(*from_data['args'], **from_data['kwargs'])
+
+        mdb.learn(
+            from_data=data_source,
+            to_predict=to_predict,
+            #Needs to be fixed
+            use_gpu=True,
+            **kwargs
+        )
+
+        stats = mdb.get_model_data()['data_analysis_v2']
+
+        try:
+            assert(config['interface']['clickhouse']['enabled'] == True)
+            from mindsdb_server.interfaces.clickhouse.clickhouse import Clickhouse
+            clickhouse = Clickhouse(config)
+            clickhouse.register_predictor(name, stats)
+        except:
+            pass

--- a/mindsdb_server/interfaces/native/mindsdb.py
+++ b/mindsdb_server/interfaces/native/mindsdb.py
@@ -9,7 +9,6 @@ class MindsdbNative():
     def __init__(self, config):
         self.config = config
         self.metapredictor = mindsdb.Predictor('metapredictor')
-        self.register_to = []
         self.unregister_from = []
 
         try:

--- a/mindsdb_server/interfaces/native/mindsdb.py
+++ b/mindsdb_server/interfaces/native/mindsdb.py
@@ -1,9 +1,8 @@
 # Mindsdb native interface
-import sys
 import mindsdb
-import lightwood
-import torch.multiprocessing as mp
 from dateutil.parser import parse as parse_datetime
+
+from mindsdb_server.interfaces.native.learn_process import LearnProcess
 
 
 class MindsdbNative():
@@ -16,42 +15,12 @@ class MindsdbNative():
         try:
             assert(config['interface']['clickhouse']['enabled'] == True)
             from mindsdb_server.interfaces.clickhouse.clickhouse import Clickhouse
-            self.register_to.append(Clickhouse(self.config))
             self.unregister_from.append(Clickhouse(self.config))
         except:
             pass
 
-    def _learn(self, name, from_data, to_predict, kwargs):
-        '''
-        running at subprocess due to
-        ValueError: signal only works in main thread
-
-        this is work for celery worker here?
-        '''
-        import importlib
-
-        mdb = mindsdb.Predictor(name=name)
-        if sys.platform not in ['win32','cygwin','windows']:
-            lightwood.config.config.CONFIG.HELPER_MIXERS = True
-
-        data_source = getattr(mindsdb,from_data['class'])(*from_data['args'],**from_data['kwargs'])
-
-        mdb.learn(
-            from_data=data_source,
-            to_predict=to_predict,
-            #Needs to be fixed
-            use_gpu=True,
-            **kwargs
-        )
-
-        stats = mdb.get_model_data()['data_analysis_v2']
-        for entity in self.register_to:
-            register_func = getattr(entity, 'register_predictor')
-            register_func(name, stats)
-
     def learn(self, name, from_data, to_predict, kwargs={}):
-        p = mp.get_context('spawn').Process(target=self._learn, args=(name, from_data, to_predict, kwargs))
-        p.daemon = True
+        p = LearnProcess(name, from_data, to_predict, kwargs, self.config.get_all())
         p.start()
 
     def predict(self, name, when=None, when_data=None, kwargs={}):

--- a/mindsdb_server/interfaces/native/mindsdb.py
+++ b/mindsdb_server/interfaces/native/mindsdb.py
@@ -25,10 +25,21 @@ class MindsdbNative():
     def predict(self, name, when=None, when_data=None, kwargs={}):
         mdb = mindsdb.Predictor(name=name)
 
+        use_gpu = self.config.get('use_gpu', False)
         if when is not None:
-            predictions = mdb.predict(when=when, run_confidence_variation_analysis=True, use_gpu=False, **kwargs)
+            predictions = mdb.predict(
+                when=when,
+                run_confidence_variation_analysis=True,
+                use_gpu=use_gpu,
+                **kwargs
+            )
         else:
-            predictions = mdb.predict(when_data=when_data, run_confidence_variation_analysis=True, use_gpu=False,**kwargs)
+            predictions = mdb.predict(
+                when_data=when_data,
+                run_confidence_variation_analysis=True,
+                use_gpu=use_gpu,
+                **kwargs
+            )
 
         return predictions
 

--- a/mindsdb_server/utilities/config.py
+++ b/mindsdb_server/utilities/config.py
@@ -32,5 +32,8 @@ class Config(object):
     def __getitem__(self, key):
         return self._config[key]
 
+    def get(self, key, default=None):
+        return self._config.get(key, default)
+
     def get_all(self):
         return self._config

--- a/mindsdb_server/utilities/config.py
+++ b/mindsdb_server/utilities/config.py
@@ -5,8 +5,13 @@ import json
 class Config(object):
     _config = {}
 
-    def __init__(self, file_path='mindsdb_server/default_config.json'):
-        self.merge(file_path)
+    def __init__(self, config='mindsdb_server/default_config.json'):
+        if isinstance(config, dict):
+            self._update_recursive(self._config, config)
+        elif isinstance(config, str):
+            self.merge(config)
+        else:
+            raise TypeError('argument must be string or dict')
 
     def merge(self, file_path):
         if os.path.isfile(file_path):
@@ -26,3 +31,6 @@ class Config(object):
 
     def __getitem__(self, key):
         return self._config[key]
+
+    def get_all(self):
+        return self._config


### PR DESCRIPTION
1. when you pass config-object to Process.args (through self.register_to[Clickhouse(config)]) with 'spawn' context, args passing to new process using pickle and therefore class lost internal state. To avoid it i pass config as dict and init new class in new process.
2. lightwood used only in learn process, so it will better to import it in this process.
3. little carried away so moved _learn method to separate class